### PR TITLE
fixed pip3 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ git clone https://github.com/Tuhinshubhra/ExtAnalysis
 $ cd ExtAnalysis
  ```
  ```
-$ pip3 install -r requirements.txt
+$ pip3 install -r requirements.txt --use-deprecated=backtrack-on-build-failures
  ```
 
 For proper analysis don't forget to add your virustotal api.
@@ -143,3 +143,4 @@ Attribution to all the third-party libraries used can be found in the [CREDITS](
 
 <br>
 <h4 align="center">Copyright (C) 2019 - 2022 Tuhinshubhra</h4>
+<h4 altered, ever so slightly, by 3dgecas3 in 2023</h4>


### PR DESCRIPTION
on Pop!_OS 22.04 LTS, with Python 3.10.6, using pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10) as pip3, i had to include some extra bits in the pip3 install command to successfully build the packages.
```
pip3 install -r requirements.txt --use-deprecated=backtrack-on-build-failures
```